### PR TITLE
Fix bug where findLogins would bail out after first hidden entry found

### DIFF
--- a/kprpc.ts
+++ b/kprpc.ts
@@ -237,17 +237,23 @@ const impl = {
                 const dbConfig = modelMasher.getDatabaseKPRPCConfig(file.db);
 
                 const homeGroup = modelMasher.getRootPwGroup(file.db);
+
+                let totalAll = 0;
+                let totalEntries = 0;
+
                 for (const it of homeGroup.allGroupsAndEntriesFiltered( (groupOrEntry) => {
                     // halt iteration down into this group if it's in the recycle bin
                     if (groupOrEntry instanceof KdbxGroup && groupOrEntry.uuid.equals(file.db.meta.recycleBinUuid)) return false;
                     return true;
                 })) {
+                    totalAll++;
                     // not interested in groups
                     if (it instanceof KdbxGroup) continue;
+                    totalEntries++;
 
                     const conf = ModelMasher.getEntryConfig(it, dbConfig);
 
-                    if (conf == null || conf.hide) { return; }
+                    if (conf == null || conf.hide) { continue; }
 
                     let entryIsAMatch = false;
                     let bestMatchAccuracy = 0;
@@ -319,6 +325,7 @@ const impl = {
                             {fullDetail: true, matchAccuracy: bestMatchAccuracy}));
                     }
                 }
+                logger.debug('total entries: ' + totalEntries + '. total all: ' + totalAll);
             });
 
             allEntries.sort((a, b) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kprpc",
-  "version": "1.3.2",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kprpc",
-      "version": "1.3.2",
+      "version": "1.3.7",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "jrpc": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kprpc",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "A KeePassRPC server",
   "main": "main.js",
   "types": "main.d.ts",


### PR DESCRIPTION
root cause: kdbxweb API changed to a generator and one return statement was subsequently not converted to a continue